### PR TITLE
⚡ Bolt: [performance improvement] Batch canvas path operations in games

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2026-05-19 - Batching Canvas Path Operations
 **Learning:** Calling `ctx.strokeRect` in a tight loop for a grid is highly inefficient (e.g. 400 calls per frame for a 20x20 grid) and causes performance drops on the frontend.
 **Action:** Always batch grid drawing or repeated lines into a single path using `ctx.beginPath()`, `ctx.moveTo()`, `ctx.lineTo()`, and finally `ctx.stroke()`.
+## 2026-05-21 - Batching Canvas Operations in Loops
+**Learning:** Calling `ctx.fillRect` inside loops (e.g. iterating over bullets or enemies) causes a high number of draw calls per frame which can significantly hurt performance.
+**Action:** Always batch these drawing operations using `ctx.beginPath()`, iterating over the array with `ctx.rect()`, and finishing with a single `ctx.fill()` outside the loop, as long as the fill color remains the same.

--- a/src/games/Asteroids.jsx
+++ b/src/games/Asteroids.jsx
@@ -159,11 +159,14 @@ function Asteroids() {
     ctx.stroke()
     ctx.restore()
 
+    // ⚡ Bolt Optimization: Batch bullet drawing operations to reduce the number of draw calls per frame
     // Bullets
     ctx.fillStyle = '#fff'
+    ctx.beginPath()
     g.bullets.forEach(b => {
-      ctx.fillRect(b.x - 2, b.y - 2, 4, 4)
+      ctx.rect(b.x - 2, b.y - 2, 4, 4)
     })
+    ctx.fill()
 
     // Asteroids
     ctx.strokeStyle = '#fff'

--- a/src/games/Shooter2D.jsx
+++ b/src/games/Shooter2D.jsx
@@ -129,17 +129,23 @@ function Shooter2D() {
     ctx.fillStyle = '#4ade80'
     ctx.fillRect(g.player.x - g.player.size / 2, g.player.y - g.player.size / 2, g.player.size, g.player.size)
 
+    // ⚡ Bolt Optimization: Batch drawing operations to reduce the number of draw calls per frame
+
     // Bullets
     ctx.fillStyle = '#fbbf24'
+    ctx.beginPath()
     g.bullets.forEach(b => {
-      ctx.fillRect(b.x - 2, b.y - 5, 4, 10)
+      ctx.rect(b.x - 2, b.y - 5, 4, 10)
     })
+    ctx.fill()
 
     // Enemies
     ctx.fillStyle = '#ef4444'
+    ctx.beginPath()
     g.enemies.forEach(e => {
-      ctx.fillRect(e.x - e.size / 2, e.y - e.size / 2, e.size, e.size)
+      ctx.rect(e.x - e.size / 2, e.y - e.size / 2, e.size, e.size)
     })
+    ctx.fill()
   }
 
   useEffect(() => {

--- a/src/games/SpaceInvaders.jsx
+++ b/src/games/SpaceInvaders.jsx
@@ -141,17 +141,25 @@ function SpaceInvaders() {
     ctx.fillStyle = '#fff'
     ctx.fillRect(g.player.x, g.player.y, g.player.w, g.player.h)
 
+    // ⚡ Bolt Optimization: Batch drawing operations to reduce the number of draw calls per frame
+
     // Player bullets
     ctx.fillStyle = '#4ade80'
-    g.bullets.forEach(b => ctx.fillRect(b.x, b.y, 3, 10))
+    ctx.beginPath()
+    g.bullets.forEach(b => ctx.rect(b.x, b.y, 3, 10))
+    ctx.fill()
 
     // Alien bullets
     ctx.fillStyle = '#f87171'
-    g.alienBullets.forEach(b => ctx.fillRect(b.x, b.y, 3, 10))
+    ctx.beginPath()
+    g.alienBullets.forEach(b => ctx.rect(b.x, b.y, 3, 10))
+    ctx.fill()
 
     // Aliens
     ctx.fillStyle = '#e74c3c'
-    g.aliens.forEach(a => ctx.fillRect(a.x, a.y, a.w, a.h))
+    ctx.beginPath()
+    g.aliens.forEach(a => ctx.rect(a.x, a.y, a.w, a.h))
+    ctx.fill()
   }
 
   useEffect(() => {


### PR DESCRIPTION
💡 What: Optimized rendering of bullets, enemies, and aliens in `Shooter2D.jsx`, `SpaceInvaders.jsx`, and `Asteroids.jsx` by replacing repeated `ctx.fillRect` calls inside loops with batched operations using `ctx.beginPath()`, `ctx.rect()`, and `ctx.fill()`.

🎯 Why: Calling `ctx.fillRect` inside tight animation loops results in numerous independent draw calls dispatched to the renderer per frame. Consolidating path definitions and resolving them with a single fill call drastically reduces CPU overhead and improves the framerate.

📊 Impact: Reduces the number of draw calls per frame significantly, improving performance and avoiding dropped frames when many entities (bullets, enemies, aliens) are rendered simultaneously on screen.

🔬 Measurement: Profile the application's framerate and CPU usage while repeatedly playing these three games using browser devtools (Performance tab) and observe the reduction in time spent in rendering path operations.

---
*PR created automatically by Jules for task [5680204036403200497](https://jules.google.com/task/5680204036403200497) started by @Rsmk27*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized canvas rendering performance in Asteroids, Shooter2D, and Space Invaders by consolidating drawing operations for bullets and enemies. This reduces render calls per frame while maintaining visual consistency.

* **Documentation**
  * Added technical guidance on canvas operation batching practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Rsmk27/playzone/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->