### PR TITLE
⚡ Bolt: [performance improvement] Optimize Maze Canvas Drawing

### DIFF
--- a/src/games/Maze.jsx
+++ b/src/games/Maze.jsx
@@ -52,14 +52,17 @@ const Maze = () => {
     ctx.fillStyle = '#fff';
     ctx.fillRect(0, 0, canvas.width, canvas.height);
 
+    // ⚡ Bolt Optimization: Batch grid drawing into a single path to prevent unnecessary draw calls
+    ctx.fillStyle = '#1e293b';
+    ctx.beginPath();
     for (let y = 0; y < size; y++) {
       for (let x = 0; x < size; x++) {
         if (maze[y][x] === 1) {
-          ctx.fillStyle = '#1e293b';
-          ctx.fillRect(x * cell, y * cell, cell, cell);
+          ctx.rect(x * cell, y * cell, cell, cell);
         }
       }
     }
+    ctx.fill();
 
     // Goal
     ctx.fillStyle = '#fbbf24';


### PR DESCRIPTION
💡 What: Replaced a tight nested loop of `ctx.fillRect` with batched `ctx.rect` calls wrapped in a single `ctx.beginPath()` and `ctx.fill()`.
🎯 Why: Drawing hundreds of individual rectangles using `fillRect` triggers separate draw calls, which is a known performance bottleneck for canvas (especially when run frequently during game interactions).
📊 Impact: Reduces draw calls from ~625 to 1 per frame for rendering the maze walls. Expected to yield significantly smoother performance and reduced CPU overhead.
🔬 Measurement: Verify visually or trace Canvas API calls using browser dev tools during maze gameplay (rendering is visually identical).

---
*PR created automatically by Jules for task [13113695158249437645](https://jules.google.com/task/13113695158249437645) started by @Rsmk27*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized maze rendering performance by batching wall tile drawing operations for improved efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Rsmk27/playzone/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->