### PR TITLE
🧹 Remove unused useEffect import in NumberGuessing

### DIFF
--- a/src/games/NumberGuessing.jsx
+++ b/src/games/NumberGuessing.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef } from 'react'
 
 const MAX = 100
 const MAX_TRIES = 8


### PR DESCRIPTION
🎯 **What:** Removed the unused `useEffect` import from `src/games/NumberGuessing.jsx`.
💡 **Why:** Unused imports add unnecessary dependencies and visual clutter. Removing it improves maintainability and readability.
✅ **Verification:** Compiled the application successfully using `npm run build` to verify no functionality is broken.
✨ **Result:** Cleaned up the `react` imports in the `NumberGuessing` component, improving code cleanliness.

---
*PR created automatically by Jules for task [6729964035995344256](https://jules.google.com/task/6729964035995344256) started by @Rsmk27*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up internal code imports.

This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->