### PR TITLE
🧹 Remove unused useEffect import in SimonSays

### DIFF
--- a/src/games/SimonSays.jsx
+++ b/src/games/SimonSays.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useCallback, useRef } from 'react'
 
 const PADS = [
   { id: 0, label: 'Red',    color: '#f87171', glow: 'rgba(248,113,113,0.7)', dark: '#7f1d1d' },


### PR DESCRIPTION
🎯 **What:** Removed the unused `useEffect` import from `src/games/SimonSays.jsx`.
💡 **Why:** Unused imports add unnecessary dependencies and visual clutter, negatively impacting code maintainability.
✅ **Verification:** Verified that the code builds correctly via `npm run build` after the removal, confirming no functionality is broken.
✨ **Result:** Improved maintainability and cleanliness of the `SimonSays` component by removing unnecessary code.

---
*PR created automatically by Jules for task [16671216605655559484](https://jules.google.com/task/16671216605655559484) started by @Rsmk27*