### PR TITLE
🔒 Fix Missing Sandbox Attribute on Iframe vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -757,7 +756,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.11.tgz",
       "integrity": "sha512-yxADFW35LYkP8oSGobGsYIrI42I+GPCvKTNHx4meT9Yq3C950IVz1eANoBk822I9tbKv1wyv9P4Bv1G5TpucFw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.2",
         "@firebase/logger": "0.5.0",
@@ -824,7 +822,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.11.tgz",
       "integrity": "sha512-KaACDjXkK5VLpI01vEs592R7/8s5DjFdIXfKoR385ly1SmK3Tu+jMHCIB4MsiY5jsez6v7VlEX/3rJ90dVkHyA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.11",
         "@firebase/component": "0.7.2",
@@ -841,7 +838,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.4.tgz",
       "integrity": "sha512-crX9TA5SVYZwLPG7/R16IsH8FLlgkPXjJUVhsVpHVDSqJiq3D/NuFTM5ctxGTExXAOeIn//69tQw47CPerM8MQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/logger": "0.5.0"
       }
@@ -1295,7 +1291,6 @@
       "integrity": "sha512-AmWf3cHAOMbrCPG4xdPKQaj5iHnyYfyLKZxwz+Xf55bqKbpAmcYifB4jQinT2W9XhDRHISOoPyBOariJpCG6FA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -1894,7 +1889,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1988,7 +1982,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2440,7 +2433,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2453,7 +2445,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2682,7 +2673,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -271,6 +271,7 @@ function GamePage() {
           }}>
             <iframe 
               src={`/games/${slug}/index.html`} 
+              sandbox="allow-scripts allow-same-origin"
               style={{ 
                 width: '100%', 
                 height: '100%', 


### PR DESCRIPTION
🎯 **What:** The `iframe` used to render games in `src/App.jsx` lacked a `sandbox` attribute. This PR adds `sandbox="allow-scripts allow-same-origin"` to the `iframe`.

⚠️ **Risk:** Without a `sandbox` attribute, any scripts executed inside the game's `iframe` have full access to the parent window and DOM. If a game contained malicious scripts (or was vulnerable to script injection), an attacker could exploit this to perform actions in the context of the main application, such as top-level navigation, form submission, or accessing sensitive data, completely bypassing the principle of least privilege.

🛡️ **Solution:** By adding the `sandbox` attribute with only the `allow-scripts` (required for the games to run) and `allow-same-origin` (required for games using `localStorage` for high scores) values, we restrict the `iframe` capabilities. We prevent potentially harmful actions such as popups, form submissions, and top-level navigation. Since the games run from the same origin, combining `allow-scripts` and `allow-same-origin` does technically allow an escape from the sandbox to the parent frame, but it restricts many other capabilities, so it is a good first step towards better security.

---
*PR created automatically by Jules for task [8536531959089560724](https://jules.google.com/task/8536531959089560724) started by @Rsmk27*