### PR TITLE
🧹 [code health improvement] Remove unused useEffect import in TicTacToe

### DIFF
--- a/src/games/TicTacToe.jsx
+++ b/src/games/TicTacToe.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useRef, useCallback } from 'react'
 
 // ── Win combinations + their SVG line coords ─────────────────────────────────
 const WIN_LINES = [


### PR DESCRIPTION
🎯 What: Removed the unused `useEffect` import from `src/games/TicTacToe.jsx`.

💡 Why: Unused imports add unnecessary dependencies and visual clutter. Removing them improves the maintainability and readability of the codebase.

✅ Verification: Verified that the file still compiles and the React application builds without errors using `npm run build`.

✨ Result: A cleaner, more maintainable file with no unused imports.

---
*PR created automatically by Jules for task [17741535384769388670](https://jules.google.com/task/17741535384769388670) started by @Rsmk27*