### PR TITLE
⚡ Bolt: Optimize Space Invaders and Shooter 2D canvas draw calls

### DIFF
--- a/src/games/Shooter2D.jsx
+++ b/src/games/Shooter2D.jsx
@@ -130,16 +130,22 @@ function Shooter2D() {
     ctx.fillRect(g.player.x - g.player.size / 2, g.player.y - g.player.size / 2, g.player.size, g.player.size)
 
     // Bullets
+    // ⚡ Bolt Optimization: Batch bullet rendering into a single path using beginPath/rect/fill to minimize draw calls per frame
     ctx.fillStyle = '#fbbf24'
+    ctx.beginPath()
     g.bullets.forEach(b => {
-      ctx.fillRect(b.x - 2, b.y - 5, 4, 10)
+      ctx.rect(b.x - 2, b.y - 5, 4, 10)
     })
+    ctx.fill()
 
     // Enemies
+    // ⚡ Bolt Optimization: Batch enemy rendering into a single path using beginPath/rect/fill to minimize draw calls per frame
     ctx.fillStyle = '#ef4444'
+    ctx.beginPath()
     g.enemies.forEach(e => {
-      ctx.fillRect(e.x - e.size / 2, e.y - e.size / 2, e.size, e.size)
+      ctx.rect(e.x - e.size / 2, e.y - e.size / 2, e.size, e.size)
     })
+    ctx.fill()
   }
 
   useEffect(() => {

--- a/src/games/SpaceInvaders.jsx
+++ b/src/games/SpaceInvaders.jsx
@@ -142,16 +142,25 @@ function SpaceInvaders() {
     ctx.fillRect(g.player.x, g.player.y, g.player.w, g.player.h)
 
     // Player bullets
+    // ⚡ Bolt Optimization: Batch bullet rendering into a single path using beginPath/rect/fill to minimize draw calls per frame
     ctx.fillStyle = '#4ade80'
-    g.bullets.forEach(b => ctx.fillRect(b.x, b.y, 3, 10))
+    ctx.beginPath()
+    g.bullets.forEach(b => ctx.rect(b.x, b.y, 3, 10))
+    ctx.fill()
 
     // Alien bullets
+    // ⚡ Bolt Optimization: Batch alien bullet rendering into a single path using beginPath/rect/fill to minimize draw calls per frame
     ctx.fillStyle = '#f87171'
-    g.alienBullets.forEach(b => ctx.fillRect(b.x, b.y, 3, 10))
+    ctx.beginPath()
+    g.alienBullets.forEach(b => ctx.rect(b.x, b.y, 3, 10))
+    ctx.fill()
 
     // Aliens
+    // ⚡ Bolt Optimization: Batch alien rendering into a single path using beginPath/rect/fill to minimize draw calls per frame
     ctx.fillStyle = '#e74c3c'
-    g.aliens.forEach(a => ctx.fillRect(a.x, a.y, a.w, a.h))
+    ctx.beginPath()
+    g.aliens.forEach(a => ctx.rect(a.x, a.y, a.w, a.h))
+    ctx.fill()
   }
 
   useEffect(() => {


### PR DESCRIPTION
💡 What: Replaced repeated `ctx.fillRect` calls in loops with `ctx.beginPath()`, `ctx.rect()`, and `ctx.fill()` in `SpaceInvaders.jsx` and `Shooter2D.jsx`.
🎯 Why: Calling `fillRect` inside loops generates a new draw call for every single entity (bullet, enemy, alien) per frame, slowing down canvas rendering.
📊 Impact: Reduces draw calls from dozens per frame to ~3 per frame.
🔬 Measurement: Verify smooth performance using `npm run dev` and playing Space Invaders and 2D Shooter games. Added `.jules/bolt.md` entry.

---
*PR created automatically by Jules for task [6002545265186986572](https://jules.google.com/task/6002545265186986572) started by @Rsmk27*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized game object rendering in Shooter2D and Space Invaders for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->