### PR TITLE
🧪 Add tests for MongoDB connection handling

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,8 +1,10 @@
-🎯 **What:**
-Replaced `Math.random()` with `window.crypto.getRandomValues()` in `src/games/DiceRoller.jsx` for dice roll generation.
+🎯 **What:** The testing gap in `lib/mongodb.ts` addressed. The `connectToDatabase` function previously lacked unit tests for MongoDB connection handling, caching, and error scenarios.
 
-⚠️ **Risk:**
-`Math.random()` is not cryptographically secure, meaning its output can be predictable if the internal state of the PRNG is deduced. In the context of a game, predictability allows a malicious user or script to anticipate future dice rolls and potentially exploit the game logic.
+📊 **Coverage:** The test suite now covers:
+- Missing `MONGODB_URI` environment variable error
+- Successful database connection initialization
+- Connection caching (returning existing connection without reconnecting)
+- Connection failure handling and promise resetting
+- Reusing in-flight connection promise for concurrent requests
 
-🛡️ **Solution:**
-Created a `getSecureRandom` helper function that leverages the Web Crypto API (`window.crypto.getRandomValues()`) to generate a cryptographically secure random 32-bit unsigned integer, which is then mapped securely to the 1-6 range. This ensures that dice rolls are truly random and not susceptible to PRNG state attacks. Both the animation loop and the final result calculation have been updated to use this secure method.
+✨ **Result:** Increased test coverage and reliability for the critical database connection logic, ensuring that caching and error handling work as expected.

--- a/tests/mongodb.test.ts
+++ b/tests/mongodb.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import mongoose from 'mongoose';
+
+vi.mock('mongoose', () => ({
+  default: {
+    connect: vi.fn(),
+  },
+}));
+
+describe('connectToDatabase', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv('MONGODB_URI', 'mongodb://localhost:27017/test');
+
+    // Setup global variable to prevent TypeError if not already present
+    if (!(globalThis as any).mongoose) {
+      (globalThis as any).mongoose = { conn: null, promise: null };
+    } else {
+      (globalThis as any).mongoose.conn = null;
+      (globalThis as any).mongoose.promise = null;
+    }
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('throws an error if MONGODB_URI is not defined', async () => {
+    vi.stubEnv('MONGODB_URI', '');
+    delete process.env.MONGODB_URI;
+
+    // Check if the module load throws an error, or if the function call throws an error.
+    // In our implementation, MONGODB_URI is read *inside* the function.
+    // But let's handle both cases to be completely safe against different implementations.
+    try {
+      const { connectToDatabase } = await import('../lib/mongodb');
+      await expect(connectToDatabase()).rejects.toThrow(
+        'Please define the MONGODB_URI environment variable inside .env.local'
+      );
+    } catch (e: any) {
+      // If it throws during import
+      expect(e.message).toContain('Please define the MONGODB_URI environment variable inside .env.local');
+    }
+  });
+
+  it('connects to mongodb successfully', async () => {
+    const mockMongoose = { connection: { readyState: 1 } };
+    vi.mocked(mongoose.connect).mockResolvedValueOnce(mockMongoose as any);
+
+    // Import dynamically after changing env var
+    const { connectToDatabase } = await import('../lib/mongodb');
+    const conn = await connectToDatabase();
+
+    expect(mongoose.connect).toHaveBeenCalledTimes(1);
+    expect(mongoose.connect).toHaveBeenCalledWith('mongodb://localhost:27017/test', {
+      bufferCommands: false,
+    });
+    expect(conn).toBe(mockMongoose);
+  });
+
+  it('returns cached connection if it exists', async () => {
+    const mockMongoose = { connection: { readyState: 1 } };
+    (globalThis as any).mongoose.conn = mockMongoose;
+
+    // Import dynamically
+    const { connectToDatabase } = await import('../lib/mongodb');
+    const conn = await connectToDatabase();
+
+    expect(mongoose.connect).not.toHaveBeenCalled();
+    expect(conn).toBe(mockMongoose);
+  });
+
+  it('handles connection failure and resets promise', async () => {
+    const error = new Error('Connection failed');
+    vi.mocked(mongoose.connect).mockRejectedValueOnce(error);
+
+    // Import dynamically
+    const { connectToDatabase } = await import('../lib/mongodb');
+    await expect(connectToDatabase()).rejects.toThrow('Connection failed');
+
+    // The promise should be set to null after failure
+    expect((globalThis as any).mongoose.promise).toBeNull();
+  });
+
+  it('reuses the connection promise if connecting is in progress', async () => {
+    const mockMongoose = { connection: { readyState: 1 } };
+
+    let resolveConnection: any;
+    const connectPromise = new Promise((resolve) => {
+      resolveConnection = resolve;
+    });
+
+    vi.mocked(mongoose.connect).mockReturnValueOnce(connectPromise as any);
+
+    // Import dynamically
+    const { connectToDatabase } = await import('../lib/mongodb');
+
+    // Call connectToDatabase twice
+    const p1 = connectToDatabase();
+    const p2 = connectToDatabase();
+
+    // Resolve the connection
+    resolveConnection(mockMongoose);
+
+    const [conn1, conn2] = await Promise.all([p1, p2]);
+
+    // mongoose.connect should only be called once
+    expect(mongoose.connect).toHaveBeenCalledTimes(1);
+    expect(conn1).toBe(mockMongoose);
+    expect(conn2).toBe(mockMongoose);
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap in `lib/mongodb.ts` addressed. The `connectToDatabase` function previously lacked unit tests for MongoDB connection handling, caching, and error scenarios.

📊 **Coverage:** The test suite now covers:
- Missing `MONGODB_URI` environment variable error
- Successful database connection initialization
- Connection caching (returning existing connection without reconnecting)
- Connection failure handling and promise resetting
- Reusing in-flight connection promise for concurrent requests

✨ **Result:** Increased test coverage and reliability for the critical database connection logic, ensuring that caching and error handling work as expected.

---
*PR created automatically by Jules for task [15287868986858719621](https://jules.google.com/task/15287868986858719621) started by @Rsmk27*