### PR TITLE
🧹 [Remove unused React import from Maze.jsx]

### DIFF
--- a/src/games/Maze.jsx
+++ b/src/games/Maze.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 
 const Maze = () => {
   const canvasRef = useRef(null);


### PR DESCRIPTION
🎯 **What:** Removed the unused `React` default import from `src/games/Maze.jsx`.

💡 **Why:** This improves code maintainability and readability by eliminating dead code and unused variables, adhering to modern React practices where `React` does not need to be in scope for JSX.

✅ **Verification:** Ran `npm run build` to verify the application builds successfully without the unused import.

✨ **Result:** Cleaner code in `Maze.jsx` with no behavioral changes.

---
*PR created automatically by Jules for task [1322551824253849569](https://jules.google.com/task/1322551824253849569) started by @Rsmk27*